### PR TITLE
Fix: bug when trying to load zsh-[name].zsh plugins

### DIFF
--- a/zapack/load_init_script.zsh
+++ b/zapack/load_init_script.zsh
@@ -30,9 +30,13 @@ function zpk::load_init_script_if_available () {
     local repo_name=$(zpk::get_repo_name "$repo")
     local script
 
-    script=$(ls "$repo/$repo_name.zsh" "$repo/$repo_name.sh" "$repo/$repo_name" 2> /dev/null | head -1) \
-        || script=$(ls "$repo/$(zpk::extract_name_from_case_of_prefix_zsh "$repo").zsh" 2> /dev/null) \
-        || script=$(ls "$repo/$(zpk::extract_name_from_case_of_prefix_sh "$repo").sh" 2> /dev/null)
+    # Use "find -print -quit" to print the first matching file
+    script=$(find \
+        "$repo/$repo_name.zsh" "$repo/$repo_name.sh" "$repo/$repo_name" \
+        "$repo/$(zpk::extract_name_from_case_of_prefix_zsh "$repo_name").zsh" \
+        "$repo/$(zpk::extract_name_from_case_of_prefix_sh "$repo_name").sh" \
+        -maxdepth 0 -type f -print -quit 2> /dev/null
+    )
 
     if [[ -f $script ]] ; then
         source "$script"


### PR DESCRIPTION
Hi 

I discovered zapack and I love the idea !
But I was trying to use it to load [zsh-autoenv](https://github.com/Tarrasch/zsh-autoenv) and it didn't worked (zapack didn't found `autoenv.zsh`.
I digged a while and found that the tests in load_init_script_if_available() were incorrect:

- $repo was passed to extract_name_from_case_of_prefix_(z)sh functions, but $repo_name should be passed
- the `ls` trick with || does not work when the matching file is the second line (that's the case with `zsh-autoenv`)

Here's a working solution using `find` with `-print` and `quit` options: find will test for each given files as params if this is a regular file, and will "return" (print) the first matching filename.